### PR TITLE
RDDFC-640: Fix load balancer issue

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -295,7 +295,9 @@ stages:
               chartType: 'FilePath'
               chartPath: '$(ProjectPath)/charts/fission-all'
               releaseName: '${{ parameters.ProjectName }}'
-              arguments: '--recreate-pods --reuse-values'
+              force: true
+              recreate: true
+              arguments: '--reuse-values'
 
       ########################################################################################################################
       # CREATE A NEW GIT RELEASE


### PR DESCRIPTION
Fixes RDDFC-640 by adding `--force` to the Helm upgrade command.
In order to do this I had to create a PVC manually in EKS and configure Fission to use it (rather than creating it's own PVC).